### PR TITLE
fix error in i16 bindings

### DIFF
--- a/InputCommands/I-16/Input/I-16/joystick/default.lua
+++ b/InputCommands/I-16/Input/I-16/joystick/default.lua
@@ -39,7 +39,7 @@ return {
 		{cockpit_device_id = devices.GEAR_SYSTEM, down = 3051, value_down = 1, name = _('Gear direction UP'), category = {_('Systems'), _('Custom')}},
 
 		{cockpit_device_id = devices.GEAR_SYSTEM, down = 3069, up = 3069, value_down = 1, value_up = 0, name = _('Gear lock ON else OFF (2-way Switch)'), category = {_('Systems'), _('Custom')}},
-		{cockpit_device_id = devices.GEAR_SYSTEM, down = 3069, up = 3069, value_down = 1, value_up = 0, name = _('Gear brake spring ON else OFF (2-way Switch)'), category = {_('Systems'), _('Custom')}},
+		{cockpit_device_id = devices.GEAR_SYSTEM, down = 3055, up = 3055, value_down = 1, value_up = 0, name = _('Gear brake spring ON else OFF (2-way Switch)'), category = {_('Systems'), _('Custom')}},
 
 		{cockpit_device_id = devices.MOTOR_SYSTEM, down = 3006, up = 3006, value_down = 0.5, value_up = 0.0, name = _('Motor cooling flaps Increase (Slow)'), category = {_('Engine Control'), _('Custom')}},
 		{cockpit_device_id = devices.MOTOR_SYSTEM, down = 3006, up = 3006, value_down = -0.5, value_up = 0.0, name = _('Motor cooling flaps Decrease (Slow)'), category = {_('Engine Control'), _('Custom')}},


### PR DESCRIPTION
the gear spring toggle had the wrong command ID, it used the ID of the gear lock command, making it a duplicate of the previous line.