### PR TITLE
Fix wording of I-16 gear lock

### DIFF
--- a/InputCommands/I-16/Input/I-16/joystick/default.lua
+++ b/InputCommands/I-16/Input/I-16/joystick/default.lua
@@ -38,7 +38,7 @@ return {
 		{cockpit_device_id = devices.GEAR_SYSTEM, down = 3051, value_down = 0, name = _('Gear direction DOWN'), category = {_('Systems'), _('Custom')}},
 		{cockpit_device_id = devices.GEAR_SYSTEM, down = 3051, value_down = 1, name = _('Gear direction UP'), category = {_('Systems'), _('Custom')}},
 
-		{cockpit_device_id = devices.GEAR_SYSTEM, down = 3050, up = 3050, value_down = 1, value_up = 0, name = _('Gear lock ON else OFF (2-way Switch)'), category = {_('Systems'), _('Custom')}},
+		{cockpit_device_id = devices.GEAR_SYSTEM, down = 3050, up = 3050, value_down = 1, value_up = 0, name = _('Gear lock OFF else ON (2-way Switch)'), category = {_('Systems'), _('Custom')}},
 		{cockpit_device_id = devices.GEAR_SYSTEM, down = 3055, up = 3055, value_down = 1, value_up = 0, name = _('Gear brake spring ON else OFF (2-way Switch)'), category = {_('Systems'), _('Custom')}},
 
 		{cockpit_device_id = devices.MOTOR_SYSTEM, down = 3006, up = 3006, value_down = 0.5, value_up = 0.0, name = _('Motor cooling flaps Increase (Slow)'), category = {_('Engine Control'), _('Custom')}},

--- a/InputCommands/I-16/Input/I-16/joystick/default.lua
+++ b/InputCommands/I-16/Input/I-16/joystick/default.lua
@@ -39,6 +39,7 @@ return {
 		{cockpit_device_id = devices.GEAR_SYSTEM, down = 3051, value_down = 1, name = _('Gear direction UP'), category = {_('Systems'), _('Custom')}},
 
 		{cockpit_device_id = devices.GEAR_SYSTEM, down = 3050, up = 3050, value_down = 1, value_up = 0, name = _('Gear lock OFF else ON (2-way Switch)'), category = {_('Systems'), _('Custom')}},
+		{cockpit_device_id = devices.GEAR_SYSTEM, down = 3050, up = 3050, value_down = 0, value_up = 1, name = _('Gear lock ON else OFF (2-way Switch)'), category = {_('Systems'), _('Custom')}},
 		{cockpit_device_id = devices.GEAR_SYSTEM, down = 3055, up = 3055, value_down = 1, value_up = 0, name = _('Gear brake spring ON else OFF (2-way Switch)'), category = {_('Systems'), _('Custom')}},
 
 		{cockpit_device_id = devices.MOTOR_SYSTEM, down = 3006, up = 3006, value_down = 0.5, value_up = 0.0, name = _('Motor cooling flaps Increase (Slow)'), category = {_('Engine Control'), _('Custom')}},

--- a/InputCommands/I-16/Input/I-16/keyboard/default.lua
+++ b/InputCommands/I-16/Input/I-16/keyboard/default.lua
@@ -38,7 +38,7 @@ return {
 		{cockpit_device_id = devices.GEAR_SYSTEM, down = 3051, value_down = 0, name = _('Gear direction DOWN'), category = {_('Systems'), _('Custom')}},
 		{cockpit_device_id = devices.GEAR_SYSTEM, down = 3051, value_down = 1, name = _('Gear direction UP'), category = {_('Systems'), _('Custom')}},
 
-		{cockpit_device_id = devices.GEAR_SYSTEM, down = 3050, up = 3050, value_down = 1, value_up = 0, name = _('Gear lock ON else OFF (2-way Switch)'), category = {_('Systems'), _('Custom')}},
+		{cockpit_device_id = devices.GEAR_SYSTEM, down = 3050, up = 3050, value_down = 1, value_up = 0, name = _('Gear lock OFF else ON (2-way Switch)'), category = {_('Systems'), _('Custom')}},
 		{cockpit_device_id = devices.GEAR_SYSTEM, down = 3055, up = 3055, value_down = 1, value_up = 0, name = _('Gear brake spring ON else OFF (2-way Switch)'), category = {_('Systems'), _('Custom')}},
 
 		{cockpit_device_id = devices.MOTOR_SYSTEM, down = 3006, up = 3006, value_down = 0.5, value_up = 0.0, name = _('Motor cooling flaps Increase (Slow)'), category = {_('Engine Control'), _('Custom')}},

--- a/InputCommands/I-16/Input/I-16/keyboard/default.lua
+++ b/InputCommands/I-16/Input/I-16/keyboard/default.lua
@@ -39,6 +39,7 @@ return {
 		{cockpit_device_id = devices.GEAR_SYSTEM, down = 3051, value_down = 1, name = _('Gear direction UP'), category = {_('Systems'), _('Custom')}},
 
 		{cockpit_device_id = devices.GEAR_SYSTEM, down = 3050, up = 3050, value_down = 1, value_up = 0, name = _('Gear lock OFF else ON (2-way Switch)'), category = {_('Systems'), _('Custom')}},
+		{cockpit_device_id = devices.GEAR_SYSTEM, down = 3050, up = 3050, value_down = 0, value_up = 1, name = _('Gear lock ON else OFF (2-way Switch)'), category = {_('Systems'), _('Custom')}},
 		{cockpit_device_id = devices.GEAR_SYSTEM, down = 3055, up = 3055, value_down = 1, value_up = 0, name = _('Gear brake spring ON else OFF (2-way Switch)'), category = {_('Systems'), _('Custom')}},
 
 		{cockpit_device_id = devices.MOTOR_SYSTEM, down = 3006, up = 3006, value_down = 0.5, value_up = 0.0, name = _('Motor cooling flaps Increase (Slow)'), category = {_('Engine Control'), _('Custom')}},


### PR DESCRIPTION
The toggle said Gear lock ON else OFF, but the 1 value of the gear lock command _UNLOCKS_ the I-16's gear (the forward position is _unlocked_).

I've reversed the wording, so it makes more sense, even though it's now reversed from the actual values of the command.

I also added a reversed command, which should be nice as existing bindings will still show up, and it could be useful for some.