### PR TITLE
F-16C: Add slow joystick and keyboard bindings for radar antenna elevation

### DIFF
--- a/InputCommands/F-16C/Input/F-16C/joystick/default.lua
+++ b/InputCommands/F-16C/Input/F-16C/joystick/default.lua
@@ -542,6 +542,11 @@ return {
 		{cockpit_device_id = devices.ECM_INTERFACE, down = ecm_commands.SplBtn, value_down = 1, name = _('ECM SPL Button - ON'), category = {_('ECM Control Panel'), _('Custom')}},
 		{cockpit_device_id = devices.ECM_INTERFACE, down = ecm_commands.SplBtn, up = ecm_commands.SplBtn, value_down = 0, value_up = 1, name = _('ECM SPL Button - OFF else ON (2-way Switch)'), category = {_('ECM Control Panel'), _('Custom')}},
 		{cockpit_device_id = devices.ECM_INTERFACE, down = ecm_commands.SplBtn, up = ecm_commands.SplBtn, value_down = 1, value_up = 0, name = _('ECM SPL Button - ON else OFF (2-way Switch)'), category = {_('ECM Control Panel'), _('Custom')}},
+		
+		-- HOTAS
+		
+		{cockpit_device_id = devices.HOTAS, pressed = hotas_commands.THROTTLE_ANT_ELEV_UP, value_pressed =  0.1, name = _('ANT ELEV Knob - CW (Slow)'), category = {_('Throttle Grip'), _('HOTAS'), _('Custom')}},
+		{cockpit_device_id = devices.HOTAS, pressed = hotas_commands.THROTTLE_ANT_ELEV_DOWN, value_pressed = -0.1, name = _('ANT ELEV Knob - CCW (Slow)'), category = {_('Throttle Grip'), _('HOTAS'), _('Custom')}},
 	},
 	axisCommands = {
 		{cockpit_device_id = devices.EXTLIGHTS_SYSTEM, action = extlights_commands.AntiCollKn, name = _('ANTI-COLL Knob, OFF/1/2/3/4/A/B/C')},

--- a/InputCommands/F-16C/Input/F-16C/keyboard/default.lua
+++ b/InputCommands/F-16C/Input/F-16C/keyboard/default.lua
@@ -542,5 +542,10 @@ return {
 		{cockpit_device_id = devices.ECM_INTERFACE, down = ecm_commands.SplBtn, value_down = 1, name = _('ECM SPL Button - ON'), category = {_('ECM Control Panel'), _('Custom')}},
 		{cockpit_device_id = devices.ECM_INTERFACE, down = ecm_commands.SplBtn, up = ecm_commands.SplBtn, value_down = 0, value_up = 1, name = _('ECM SPL Button - OFF else ON (2-way Switch)'), category = {_('ECM Control Panel'), _('Custom')}},
 		{cockpit_device_id = devices.ECM_INTERFACE, down = ecm_commands.SplBtn, up = ecm_commands.SplBtn, value_down = 1, value_up = 0, name = _('ECM SPL Button - ON else OFF (2-way Switch)'), category = {_('ECM Control Panel'), _('Custom')}},
+		
+		-- HOTAS
+		
+		{cockpit_device_id = devices.HOTAS, pressed = hotas_commands.THROTTLE_ANT_ELEV_UP, value_pressed =  0.1, name = _('ANT ELEV Knob - CW (Slow)'), category = {_('Throttle Grip'), _('HOTAS'), _('Custom')}},
+		{cockpit_device_id = devices.HOTAS, pressed = hotas_commands.THROTTLE_ANT_ELEV_DOWN, value_pressed = -0.1, name = _('ANT ELEV Knob - CCW (Slow)'), category = {_('Throttle Grip'), _('HOTAS'), _('Custom')}},
 	}
 }


### PR DESCRIPTION
By default, when using joystick buttons or keyboard keys to control the radar antenna elevation, the movement is uncontrollably fast. I've added "slow" joystick and keyboard bindings that change the elevation at 10% speed compared to the default bindings. This feels like a good middle ground between precision and speed.