### PR TITLE
Add 3-way switch keybinds for F-16 Pitch autopilot

### DIFF
--- a/InputCommands/F-16C/Input/F-16C/joystick/default.lua
+++ b/InputCommands/F-16C/Input/F-16C/joystick/default.lua
@@ -36,6 +36,9 @@ return {
 		{cockpit_device_id = devices.CONTROL_INTERFACE, down = control_commands.ApRoll, up = control_commands.ApRoll, value_down = -1, value_up = 0, name = _('Autopilot ROLL Switch - STRG SEL else ATT HOLD (3-way Switch Up)'), category = {_('Special For Joystick'), _('Instrument Panel'), _('FLCS'), _('Custom')}},
 		{cockpit_device_id = devices.CONTROL_INTERFACE, down = control_commands.ApRoll, up = control_commands.ApRoll, value_down = 1, value_up = 0, name = _('Autopilot ROLL Switch - HDG SEL else ATT HOLD (3-way Switch Down)'), category = {_('Special For Joystick'), _('Instrument Panel'), _('FLCS'), _('Custom')}},
 
+		{cockpit_device_id = devices.CONTROL_INTERFACE, down = control_commands.ApPitchAlt_EXT, up = control_commands.ApPitchAlt_EXT, value_down = 1, value_up = -1, name = _('Autopilot PITCH Switch - ALT HOLD else OFF (3-way Switch Up)'), category = {_('Special For Joystick'), _('Instrument Panel'), _('FLCS'), _('Custom')}},
+		{cockpit_device_id = devices.CONTROL_INTERFACE, down = control_commands.ApPitchAtt_EXT, up = control_commands.ApPitchAlt_EXT, value_down = -1, value_up = -1, name = _('Autopilot PITCH Switch - ATT HOLD else OFF (3-way Switch Down)'), category = {_('Special For Joystick'), _('Instrument Panel'), _('FLCS'), _('Custom')}},
+
 		{cockpit_device_id = devices.CONTROL_INTERFACE, down = control_commands.AdvMode, up = control_commands.AdvMode, value_down = 0, value_up = 1, name = _('ADV MODE Switch - RELEASED else DEPRESSED (2-way Switch)'), category = {_('Special For Joystick'), _('Instrument Panel'), _('FLCS'), _('Custom')}},
 		{cockpit_device_id = devices.CONTROL_INTERFACE, down = control_commands.AdvMode, up = control_commands.AdvMode, value_down = 1, value_up = 0, name = _('ADV MODE Switch - DEPRESSED else RELEASED (2-way Switch)'), category = {_('Special For Joystick'), _('Instrument Panel'), _('FLCS'), _('Custom')}},
 

--- a/InputCommands/F-16C/Input/F-16C/keyboard/default.lua
+++ b/InputCommands/F-16C/Input/F-16C/keyboard/default.lua
@@ -36,6 +36,9 @@ return {
 		{cockpit_device_id = devices.CONTROL_INTERFACE, down = control_commands.ApRoll, up = control_commands.ApRoll, value_down = -1, value_up = 0, name = _('Autopilot ROLL Switch - STRG SEL else ATT HOLD (3-way Switch Up)'), category = {_('Special For Joystick'), _('Instrument Panel'), _('FLCS'), _('Custom')}},
 		{cockpit_device_id = devices.CONTROL_INTERFACE, down = control_commands.ApRoll, up = control_commands.ApRoll, value_down = 1, value_up = 0, name = _('Autopilot ROLL Switch - HDG SEL else ATT HOLD (3-way Switch Down)'), category = {_('Special For Joystick'), _('Instrument Panel'), _('FLCS'), _('Custom')}},
 
+		{cockpit_device_id = devices.CONTROL_INTERFACE, down = control_commands.ApPitchAlt_EXT, up = control_commands.ApPitchAlt_EXT, value_down = 1, value_up = -1, name = _('Autopilot PITCH Switch - ALT HOLD else OFF (3-way Switch Up)'), category = {_('Special For Joystick'), _('Instrument Panel'), _('FLCS'), _('Custom')}},
+		{cockpit_device_id = devices.CONTROL_INTERFACE, down = control_commands.ApPitchAtt_EXT, up = control_commands.ApPitchAlt_EXT, value_down = -1, value_up = -1, name = _('Autopilot PITCH Switch - ATT HOLD else OFF (3-way Switch Down)'), category = {_('Special For Joystick'), _('Instrument Panel'), _('FLCS'), _('Custom')}},
+
 		{cockpit_device_id = devices.CONTROL_INTERFACE, down = control_commands.AdvMode, up = control_commands.AdvMode, value_down = 0, value_up = 1, name = _('ADV MODE Switch - RELEASED else DEPRESSED (2-way Switch)'), category = {_('Special For Joystick'), _('Instrument Panel'), _('FLCS'), _('Custom')}},
 		{cockpit_device_id = devices.CONTROL_INTERFACE, down = control_commands.AdvMode, up = control_commands.AdvMode, value_down = 1, value_up = 0, name = _('ADV MODE Switch - DEPRESSED else RELEASED (2-way Switch)'), category = {_('Special For Joystick'), _('Instrument Panel'), _('FLCS'), _('Custom')}},
 


### PR DESCRIPTION
When merged, this pull request will add two keybinds for the Autopilot PITCH Switch 3-way switch in the F-16: Alt hold else off, and Att hold else off. This works in the same manner as the existing Autopilot ROLL Switch.