### PR TITLE
Adding closed-else-open for main gen cover in the UH1H

### DIFF
--- a/InputCommands/Uh-1H/Input/UH-1H/joystick/Joystick - HOTAS Warthog.lua
+++ b/InputCommands/Uh-1H/Input/UH-1H/joystick/Joystick - HOTAS Warthog.lua
@@ -66,6 +66,7 @@ return {
 		{down = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 1, name = _('Main generator Switch Cover Open'), category = {_('Ins Overhead panel'), _('Custom')}},
 		{down = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 0, name = _('Main generator Switch Cover Closed'), category = {_('Ins Overhead panel'), _('Custom')}},
 		{down = device_commands.Button_19, up = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 1, value_up = 0, name = _('Main generator Switch Cover Open else Closed (2-way Switch)'), category = {_('Ins Overhead panel'), _('Custom')}},
+		{down = device_commands.Button_19, up = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 0, value_up = 1, name = _('Main generator Switch Cover Closed else Open (2-way Switch)'), category = {_('Ins Overhead panel'), _('Custom')}},
 
 		{down = device_commands.Button_3, cockpit_device_id = devices.EXT_CARGO_EQUIPMENT, value_down = 1, name = _('Cargo Safety Switch Off'), category = {_('Ins Overhead panel'), _('Custom')}},
 		{down = device_commands.Button_3, cockpit_device_id = devices.EXT_CARGO_EQUIPMENT, value_down = 0, name = _('Cargo Safety Switch Armed'), category = {_('Ins Overhead panel'), _('Custom')}},

--- a/InputCommands/Uh-1H/Input/UH-1H/joystick/Logitech G940 Joystick.lua
+++ b/InputCommands/Uh-1H/Input/UH-1H/joystick/Logitech G940 Joystick.lua
@@ -66,6 +66,7 @@ return {
 		{down = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 1, name = _('Main generator Switch Cover Open'), category = {_('Ins Overhead panel'), _('Custom')}},
 		{down = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 0, name = _('Main generator Switch Cover Closed'), category = {_('Ins Overhead panel'), _('Custom')}},
 		{down = device_commands.Button_19, up = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 1, value_up = 0, name = _('Main generator Switch Cover Open else Closed (2-way Switch)'), category = {_('Ins Overhead panel'), _('Custom')}},
+		{down = device_commands.Button_19, up = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 0, value_up = 1, name = _('Main generator Switch Cover Closed else Open (2-way Switch)'), category = {_('Ins Overhead panel'), _('Custom')}},
 
 		{down = device_commands.Button_3, cockpit_device_id = devices.EXT_CARGO_EQUIPMENT, value_down = 1, name = _('Cargo Safety Switch Off'), category = {_('Ins Overhead panel'), _('Custom')}},
 		{down = device_commands.Button_3, cockpit_device_id = devices.EXT_CARGO_EQUIPMENT, value_down = 0, name = _('Cargo Safety Switch Armed'), category = {_('Ins Overhead panel'), _('Custom')}},

--- a/InputCommands/Uh-1H/Input/UH-1H/joystick/Logitech G940 Throttle.lua
+++ b/InputCommands/Uh-1H/Input/UH-1H/joystick/Logitech G940 Throttle.lua
@@ -66,6 +66,7 @@ return {
 		{down = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 1, name = _('Main generator Switch Cover Open'), category = {_('Ins Overhead panel'), _('Custom')}},
 		{down = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 0, name = _('Main generator Switch Cover Closed'), category = {_('Ins Overhead panel'), _('Custom')}},
 		{down = device_commands.Button_19, up = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 1, value_up = 0, name = _('Main generator Switch Cover Open else Closed (2-way Switch)'), category = {_('Ins Overhead panel'), _('Custom')}},
+		{down = device_commands.Button_19, up = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 0, value_up = 1, name = _('Main generator Switch Cover Closed else Open (2-way Switch)'), category = {_('Ins Overhead panel'), _('Custom')}},
 
 		{down = device_commands.Button_3, cockpit_device_id = devices.EXT_CARGO_EQUIPMENT, value_down = 1, name = _('Cargo Safety Switch Off'), category = {_('Ins Overhead panel'), _('Custom')}},
 		{down = device_commands.Button_3, cockpit_device_id = devices.EXT_CARGO_EQUIPMENT, value_down = 0, name = _('Cargo Safety Switch Armed'), category = {_('Ins Overhead panel'), _('Custom')}},

--- a/InputCommands/Uh-1H/Input/UH-1H/joystick/Saitek X52 Flight Control System.lua
+++ b/InputCommands/Uh-1H/Input/UH-1H/joystick/Saitek X52 Flight Control System.lua
@@ -66,6 +66,7 @@ return {
 		{down = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 1, name = _('Main generator Switch Cover Open'), category = {_('Ins Overhead panel'), _('Custom')}},
 		{down = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 0, name = _('Main generator Switch Cover Closed'), category = {_('Ins Overhead panel'), _('Custom')}},
 		{down = device_commands.Button_19, up = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 1, value_up = 0, name = _('Main generator Switch Cover Open else Closed (2-way Switch)'), category = {_('Ins Overhead panel'), _('Custom')}},
+		{down = device_commands.Button_19, up = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 0, value_up = 1, name = _('Main generator Switch Cover Closed else Open (2-way Switch)'), category = {_('Ins Overhead panel'), _('Custom')}},
 
 		{down = device_commands.Button_3, cockpit_device_id = devices.EXT_CARGO_EQUIPMENT, value_down = 1, name = _('Cargo Safety Switch Off'), category = {_('Ins Overhead panel'), _('Custom')}},
 		{down = device_commands.Button_3, cockpit_device_id = devices.EXT_CARGO_EQUIPMENT, value_down = 0, name = _('Cargo Safety Switch Armed'), category = {_('Ins Overhead panel'), _('Custom')}},

--- a/InputCommands/Uh-1H/Input/UH-1H/joystick/SideWinder Force Feedback 2 Joystick.lua
+++ b/InputCommands/Uh-1H/Input/UH-1H/joystick/SideWinder Force Feedback 2 Joystick.lua
@@ -66,6 +66,7 @@ return {
 		{down = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 1, name = _('Main generator Switch Cover Open'), category = {_('Ins Overhead panel'), _('Custom')}},
 		{down = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 0, name = _('Main generator Switch Cover Closed'), category = {_('Ins Overhead panel'), _('Custom')}},
 		{down = device_commands.Button_19, up = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 1, value_up = 0, name = _('Main generator Switch Cover Open else Closed (2-way Switch)'), category = {_('Ins Overhead panel'), _('Custom')}},
+		{down = device_commands.Button_19, up = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 0, value_up = 1, name = _('Main generator Switch Cover Closed else Open (2-way Switch)'), category = {_('Ins Overhead panel'), _('Custom')}},
 
 		{down = device_commands.Button_3, cockpit_device_id = devices.EXT_CARGO_EQUIPMENT, value_down = 1, name = _('Cargo Safety Switch Off'), category = {_('Ins Overhead panel'), _('Custom')}},
 		{down = device_commands.Button_3, cockpit_device_id = devices.EXT_CARGO_EQUIPMENT, value_down = 0, name = _('Cargo Safety Switch Armed'), category = {_('Ins Overhead panel'), _('Custom')}},

--- a/InputCommands/Uh-1H/Input/UH-1H/joystick/Throttle - HOTAS Warthog.lua
+++ b/InputCommands/Uh-1H/Input/UH-1H/joystick/Throttle - HOTAS Warthog.lua
@@ -66,6 +66,7 @@ return {
 		{down = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 1, name = _('Main generator Switch Cover Open'), category = {_('Ins Overhead panel'), _('Custom')}},
 		{down = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 0, name = _('Main generator Switch Cover Closed'), category = {_('Ins Overhead panel'), _('Custom')}},
 		{down = device_commands.Button_19, up = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 1, value_up = 0, name = _('Main generator Switch Cover Open else Closed (2-way Switch)'), category = {_('Ins Overhead panel'), _('Custom')}},
+		{down = device_commands.Button_19, up = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 0, value_up = 1, name = _('Main generator Switch Cover Closed else Open (2-way Switch)'), category = {_('Ins Overhead panel'), _('Custom')}},
 
 		{down = device_commands.Button_3, cockpit_device_id = devices.EXT_CARGO_EQUIPMENT, value_down = 1, name = _('Cargo Safety Switch Off'), category = {_('Ins Overhead panel'), _('Custom')}},
 		{down = device_commands.Button_3, cockpit_device_id = devices.EXT_CARGO_EQUIPMENT, value_down = 0, name = _('Cargo Safety Switch Armed'), category = {_('Ins Overhead panel'), _('Custom')}},

--- a/InputCommands/Uh-1H/Input/UH-1H/joystick/default.lua
+++ b/InputCommands/Uh-1H/Input/UH-1H/joystick/default.lua
@@ -66,6 +66,7 @@ return {
 		{down = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 1, name = _('Main generator Switch Cover Open'), category = {_('Ins Overhead panel'), _('Custom')}},
 		{down = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 0, name = _('Main generator Switch Cover Closed'), category = {_('Ins Overhead panel'), _('Custom')}},
 		{down = device_commands.Button_19, up = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 1, value_up = 0, name = _('Main generator Switch Cover Open else Closed (2-way Switch)'), category = {_('Ins Overhead panel'), _('Custom')}},
+		{down = device_commands.Button_19, up = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 0, value_up = 1, name = _('Main generator Switch Cover Closed else Open (2-way Switch)'), category = {_('Ins Overhead panel'), _('Custom')}},
 
 		{down = device_commands.Button_3, cockpit_device_id = devices.EXT_CARGO_EQUIPMENT, value_down = 1, name = _('Cargo Safety Switch Off'), category = {_('Ins Overhead panel'), _('Custom')}},
 		{down = device_commands.Button_3, cockpit_device_id = devices.EXT_CARGO_EQUIPMENT, value_down = 0, name = _('Cargo Safety Switch Armed'), category = {_('Ins Overhead panel'), _('Custom')}},

--- a/InputCommands/Uh-1H/Input/UH-1H/keyboard/default.lua
+++ b/InputCommands/Uh-1H/Input/UH-1H/keyboard/default.lua
@@ -66,6 +66,7 @@ return {
 		{down = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 1, name = _('Main generator Switch Cover Open'), category = {_('Ins Overhead panel'), _('Custom')}},
 		{down = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 0, name = _('Main generator Switch Cover Closed'), category = {_('Ins Overhead panel'), _('Custom')}},
 		{down = device_commands.Button_19, up = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 1, value_up = 0, name = _('Main generator Switch Cover Open else Closed (2-way Switch)'), category = {_('Ins Overhead panel'), _('Custom')}},
+		{down = device_commands.Button_19, up = device_commands.Button_19, cockpit_device_id = devices.ELEC_INTERFACE, value_down = 0, value_up = 1, name = _('Main generator Switch Cover Closed else Open (2-way Switch)'), category = {_('Ins Overhead panel'), _('Custom')}},
 
 		{down = device_commands.Button_3, cockpit_device_id = devices.EXT_CARGO_EQUIPMENT, value_down = 1, name = _('Cargo Safety Switch Off'), category = {_('Ins Overhead panel'), _('Custom')}},
 		{down = device_commands.Button_3, cockpit_device_id = devices.EXT_CARGO_EQUIPMENT, value_down = 0, name = _('Cargo Safety Switch Armed'), category = {_('Ins Overhead panel'), _('Custom')}},


### PR DESCRIPTION
Adding the reverse of what's there for the Main Generator cover, since it should be closed in flight, and starts open - not the other way around!