### PR TITLE
feat: Supplement missing keys from the original key settings

### DIFF
--- a/InputCommands/A-10C_2/Input/A-10C_2/joystick/default.lua
+++ b/InputCommands/A-10C_2/Input/A-10C_2/joystick/default.lua
@@ -534,7 +534,8 @@ return {
 		{	down = iCommandPlaneKneeboardJumpBookmark,								value_down = 7,							name = _('Kneeboard Jump To Shortcut  8'),			category = _('Kneeboard')},
 		{	down = iCommandPlaneKneeboardJumpBookmark,								value_down = 8,							name = _('Kneeboard Jump To Shortcut  9'),			category = _('Kneeboard')},
 		{	down = iCommandPlaneKneeboardJumpBookmark,								value_down = 9,							name = _('Kneeboard Jump To Shortcut 10'),			category = _('Kneeboard')},
-
+		-- View
+		{down = iCommandToggleMirrors, name = _('Toggle Mirrors'), category = _('View Cockpit')},
 	}),
 	axisCommands = join(axisCommandsRadio, {
 		{action = 3013, cockpit_device_id = 38, name = _('Yaw Trim')},

--- a/InputCommands/A-10C_2/Input/A-10C_2/keyboard/default.lua
+++ b/InputCommands/A-10C_2/Input/A-10C_2/keyboard/default.lua
@@ -529,6 +529,8 @@ return {
 		{	down = iCommandPlaneKneeboardJumpBookmark,								value_down = 7,							name = _('Kneeboard Jump To Shortcut  8'),			category = _('Kneeboard')},
 		{	down = iCommandPlaneKneeboardJumpBookmark,								value_down = 8,							name = _('Kneeboard Jump To Shortcut  9'),			category = _('Kneeboard')},
 		{	down = iCommandPlaneKneeboardJumpBookmark,								value_down = 9,							name = _('Kneeboard Jump To Shortcut 10'),			category = _('Kneeboard')},
-
+		
+		-- View
+		{down = iCommandToggleMirrors, name = _('Toggle Mirrors'), category = _('View Cockpit')},
 	})
 }

--- a/InputCommands/AJS37/Input/joystick/default.lua
+++ b/InputCommands/AJS37/Input/joystick/default.lua
@@ -332,6 +332,9 @@ return {
 
 		{cockpit_device_id = devices.FLIGHTDATAUNIT, down = 3715, value_down = 0, name = _('Altimeter Setting Pull-out - NORMAL'), category = {_('Flight Data'), _('Custom')}},
 		{cockpit_device_id = devices.FLIGHTDATAUNIT, down = 3715, value_down = 1, name = _('Altimeter Setting Pull-out - PULL'), category = {_('Flight Data'), _('Custom')}},
+
+		-- View Cockpit
+		{down = iCommandCockpitShowPilotOnOff, name = _('Toggle Pilot'), category = _('View Cockpit')},
 	},
 	axisCommands = {
 		{cockpit_device_id = devices.ENGINEPANEL, action = 3304, name = _('AFK Lever')},

--- a/InputCommands/MiG-21bis/Input/MiG-21/joystick/default.lua
+++ b/InputCommands/MiG-21bis/Input/MiG-21/joystick/default.lua
@@ -819,6 +819,10 @@ return {
         {cockpit_device_id = devices.WEAPON_CONTROL, down = device_commands.GUVArm1, up = device_commands.GUVArm1, value_down = 1, value_up = 0, name = _('UPK-23 Gun Pod Reload Button 1'), category = {_('UPK-23 Gun Pod Panel'), _('Custom')}},
         {cockpit_device_id = devices.WEAPON_CONTROL, down = device_commands.GUVArm2, up = device_commands.GUVArm2, value_down = 1, value_up = 0, name = _('UPK-23 Gun Pod Reload Button 2'), category = {_('UPK-23 Gun Pod Panel'), _('Custom')}},
         {cockpit_device_id = devices.WEAPON_CONTROL, down = device_commands.GUVArm3, up = device_commands.GUVArm3, value_down = 1, value_up = 0, name = _('UPK-23 Gun Pod Reload Button 3'), category = {_('UPK-23 Gun Pod Panel'), _('Custom')}},
+
+        -- General
+        {down = iCommandViewBriefing,name=_('View briefing on/off'),category = _('General')},
+		{down = iCommandPlane_ShowControls, name=_('Show controls indicator'),category=_('General')},
     },
     axisCommands = {
         {cockpit_device_id = devices.FUEL_SYSTEM, action = device_commands.FuelQt, name = _('Fuel Quantity Set')},

--- a/InputCommands/MiG-21bis/Input/MiG-21/joystick/default.lua
+++ b/InputCommands/MiG-21bis/Input/MiG-21/joystick/default.lua
@@ -822,7 +822,7 @@ return {
 
         -- General
         {down = iCommandViewBriefing,name=_('View briefing on/off'),category = _('General')},
-		{down = iCommandPlane_ShowControls, name=_('Show controls indicator'),category=_('General')},
+        {down = iCommandPlane_ShowControls, name=_('Show controls indicator'),category=_('General')},
     },
     axisCommands = {
         {cockpit_device_id = devices.FUEL_SYSTEM, action = device_commands.FuelQt, name = _('Fuel Quantity Set')},


### PR DESCRIPTION
In the default key setting, the AJS37 pilot's body can only be displayed or hidden through the keyboard, and there is no key setting for the joystick. So add it.

Add rearview mirror toggle key for A-10C II.